### PR TITLE
Updates quil version to 2.2.4

### DIFF
--- a/curriculum/first-program.md
+++ b/curriculum/first-program.md
@@ -65,7 +65,7 @@ To add a dependency, open `project.clj`. You should see a section which reads
 
 ```clj
 :dependencies [[org.clojure/clojure "1.6.0"]
-               [quil "2.2.2"]])
+               [quil "2.2.4"]])
 ```
 
 This is where our dependencies are listed. All the dependencies we need for this project are already included.

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [quil "2.2.1"]])
+                 [quil "2.2.4"]])


### PR DESCRIPTION
A small fix just updating quil to the latest version. All apps, core.clj, lines.clj, and practice.clj worked on this version 2.2.4.