### PR TITLE
Whitespace formatting changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# drawing 
+# drawing
 
 ClojureBridge capstone app using Quil to draw.
 
 ## Usage
 
-LightTable - open `lines.clj` and press `Ctrl+Shift+Enter` to evaluate the file.
+LightTable - open `lines.clj` and press `Ctrl+Shift+Enter` to evaluate
+the file.
 
 REPL - run `(require 'drawing.lines)`.
 

--- a/curriculum/create-something.md
+++ b/curriculum/create-something.md
@@ -18,37 +18,48 @@ Clara already learned how to find the way. It was:
 1. Go to the API documentation website
 2. Google it
 
-So, Clara went to the Quil API web site, [http://quil.info/api](http://quil.info.api),
-and found the [Loading and Displaying](http://quil.info/api/image/loading-and-displaying) section. Then, she found the [background-image](http://quil.info/api/color/setting#background-image) function.
+So, Clara went to the Quil API web site,
+[http://quil.info/api](http://quil.info.api), and found the
+[Loading and Displaying](http://quil.info/api/image/loading-and-displaying)
+section. Then, she found the
+[background-image](http://quil.info/api/color/setting#background-image)
+function.
 
 Then, she googled and found a StackOverflow question,
-[Load/display image in clojure with quil](http://stackoverflow.com/questions/18714941/load-display-image-in-clojure-with-quil), which looked like what she needed.
+[Load/display image in clojure with quil](http://stackoverflow.com/questions/18714941/load-display-image-in-clojure-with-quil),
+which looked like what she needed.
 
 Those gave her enough information to accomplish step 1.
 
-At the ClojureBridge workshop, Clara went though the Quil app tutorial,
-[Making Your First Program with Quil](https://github.com/ClojureBridge/drawing/blob/master/curriculum/first-program.md), so she already had the `drawing` Clojure project.
-She decided to use the same project for her own app.
+At the ClojureBridge workshop, Clara went though the Quil app
+tutorial,
+[Making Your First Program with Quil](https://github.com/ClojureBridge/drawing/blob/master/curriculum/first-program.md),
+so she already had the `drawing` Clojure project.  She decided to use
+the same project for her own app.
 
-### create a new source file
+### Create a new source file
 
-Clara added a new file under `src/drawing` directory with the name `practice.clj`.
-At this point, her directory structure looks like the below:
+Clara added a new file under `src/drawing` directory with the name
+`practice.clj`.  At this point, her directory structure looks like the
+below:
 
 ```
 | LICENSE
 | README.md
 | project.clj
 | src
-| | drawing 
+| | drawing
 | | | core.clj
 | | | lines.clj
 | | | practice.clj
 ```
 
-### make the source code clojure-ish
+### Make the source code clojure-ish
 
-First, Clojure source code has a namespace declaration, so Clara copy-pasted `ns` from the top of her `lines.clj` file. But, she changed the name from `drawing.lines` to `drawing.practice`, because her new file has the name `practice`.
+First, Clojure source code has a namespace declaration, so Clara
+copy-pasted `ns` from the top of her `lines.clj` file. But, she
+changed the name from `drawing.lines` to `drawing.practice`, because
+her new file has the name `practice`.
 
 At this moment, `practice.clj` looks like this:
 
@@ -57,9 +68,11 @@ At this moment, `practice.clj` looks like this:
   (:require [quil.core :as q]))
 ```
 
-### add basic Quil code
+### Add basic Quil code
 
-Basic Quil code has `setup` and `draw` functions, along with a `defsketch` macro, which defines the app. Following these Quil rules, Clara added those things into her `practice.clj`.
+Basic Quil code has `setup` and `draw` functions, along with a
+`defsketch` macro, which defines the app. Following these Quil rules,
+Clara added those things into her `practice.clj`.
 
 Now, `practice.clj` looks like this:
 
@@ -79,9 +92,12 @@ Now, `practice.clj` looks like this:
   )
 ```
 
-### load snowflake and background images
+### Load snowflake and background images
 
-Looking at the Quil API and the StackOverflow question, Clara learned that where to put her image files was important. She created a new directory, `images`, under the top `drawing` directory, and she and put two images there.
+Looking at the Quil API and the StackOverflow question, Clara learned
+that where to put her image files was important. She created a new
+directory, `images`, under the top `drawing` directory, and she and
+put two images there.
 
 Now, her directory structure looks like the one below:
 
@@ -90,7 +106,7 @@ Now, her directory structure looks like the one below:
 | README.md
 | project.clj
 | src
-| | drawing 
+| | drawing
 | | | core.clj
 | | | lines.clj
 | | | practice.clj
@@ -101,7 +117,10 @@ Now, her directory structure looks like the one below:
 
 Since the images were ready, it was time to code using the Quil API.
 
-Clara added a few lines of code to the `setup` and `draw` functions in `practice.clj` to load and draw two images. She was careful when writing the image filenames because it should reflect the actual directory structure.
+Clara added a few lines of code to the `setup` and `draw` functions in
+`practice.clj` to load and draw two images. She was careful when
+writing the image filenames because it should reflect the actual
+directory structure.
 
 At this moment, `practice.clj` looks like this:
 
@@ -139,18 +158,25 @@ Woohoo! She made it!
 
 ## Step 2. Snowflake falling down
 
-Clara was satisfied with the image of the white snowflake on the blue background. However, that was boring.
+Clara was satisfied with the image of the white snowflake on the blue
+background. However, that was boring.
 
-Next, she wanted to move the snowflake like it was falling down. This needed further Quil API study and googling.
+Next, she wanted to move the snowflake like it was falling down. This
+needed further Quil API study and googling.
 
-Moving some pieces in the image is called "animation". She learned that Quil had two choices: a legacy, simple way and a new style using a framework.
+Moving some pieces in the image is called "animation". She learned
+that Quil had two choices: a legacy, simple way and a new style using
+a framework.
 
-Her choice was the new framework style, since the coding looked simple.
+Her choice was the new framework style, since the coding looked
+simple.
 
 
-### add framework
+### Add framework
 
-Clara read the document [Functional mode (fun mode)](https://github.com/quil/quil/wiki/Functional-mode-(fun-mode)) and added two lines to her `practice.clj`:
+Clara read the document
+[Functional mode (fun mode)](https://github.com/quil/quil/wiki/Functional-mode-(fun-mode))
+and added two lines to her `practice.clj`:
 
 1. `[quil.middleware :as m]` in the `ns` form
 2. `:middleware [m/fun-mode]` in the `q/defsketch` form
@@ -185,15 +211,21 @@ At this point, `practice.clj` looks like this:
   :middleware [m/fun-mode])
 ```
 
-### add state update
+### Add state update
 
-"Well," Clara thought, "What does 'moving the snowflake like it was falling down' mean in terms of programming?"
+"Well," Clara thought, "What does 'moving the snowflake like it was
+falling down' mean in terms of programming?"
 
-To draw the snowflake, she used Quil's `image` function, described in the API: [image](http://quil.info/api/image/loading-and-displaying#image).
+`To draw the snowflake, she used Quil's `image` function, described in
+the API:
+[image](http://quil.info/api/image/loading-and-displaying#image).
 
-The x and y parameters were 400 and 10 from the upper-left corner, which was the position she set to draw the snowflake. To make it fall down, the y parameter should be increased as time goes by.
+The x and y parameters were 400 and 10 from the upper-left corner,
+which was the position she set to draw the snowflake. To make it fall
+down, the y parameter should be increased as time goes by.
 
-In terms of programming, 'moving the snowflake like it was falling down' means:
+In terms of programming, 'moving the snowflake like it was falling
+down' means:
 
 1. Set the initial state--for example, `(x, y) = (400, 10)`
 2. Draw the background first, then the snowflake
@@ -201,7 +233,8 @@ In terms of programming, 'moving the snowflake like it was falling down' means:
 4. Draw the background again first, then the snowflake
 5. Repeat 2 and 3, increasing the `y` parameter.
 
-In her application, "changing state" includes only the `y` parameter. How could she increment the `y` value by one?
+In her application, "changing state" includes only the `y`
+parameter. How could she increment the `y` value by one?
 
 Yes, Clojure has the `inc` function. This is the function she used.
 
@@ -250,22 +283,31 @@ At this point, `practice.clj` looks like this:
   :middleware [m/fun-mode])
 ```
 
-When Clara ran this code--hey! She saw that the snowflake was falling down.
+When Clara ran this code--hey! She saw that the snowflake was falling
+down.
 
 
 ## Step 3. Make the snowflake keep falling down from top to bottom
 
-Clara has a nice Quil app. But, once the snowflake went down beyond the bottom line, that was it. Only a blue background remained. So, she wanted it to repeat again and again.
+Clara has a nice Quil app. But, once the snowflake went down beyond
+the bottom line, that was it. Only a blue background remained. So, she
+wanted it to repeat again and again.
 
-In other words: if the snowflake reaches the bottom, it should come back to the top. Then, it should fall down again.
+In other words: if the snowflake reaches the bottom, it should come
+back to the top. Then, it should fall down again.
 
 In terms of programming, what does that mean?
 
-If the `state` (`y` parameter) is greater than the height of the image, `state` will go back to `0`. Otherwise, the `state` will be incremented by one.
+If the `state` (`y` parameter) is greater than the height of the
+image, `state` will go back to `0`. Otherwise, the `state` will be
+incremented by one.
 
-OK, Clara learned `if`, which is used for flow control, at the ClojureBridge workshop: [Flow Control](https://github.com/ClojureBridge/curriculum/blob/master/outline/flow_control.md).
+OK, Clara learned `if`, which is used for flow control, at the
+ClojureBridge workshop:
+[Flow Control](https://github.com/ClojureBridge/curriculum/blob/master/outline/flow_control.md).
 
-So, she used `if` to make the snowflake go back to the top in the update function.
+So, she used `if` to make the snowflake go back to the top in the
+update function.
 
 At this point, `practice.clj` looks like this:
 
@@ -306,16 +348,21 @@ At this point, `practice.clj` looks like this:
   :middleware [m/fun-mode])
 ```
 
-Clara saw the snowflake appear from the top after it went down below the bottom line.
+Clara saw the snowflake appear from the top after it went down below
+the bottom line.
 
 
 ## Step 4. Make more snowflakes fall down from top to bottom
 
-Looking at the snowflake fall down many times is nice. But, Clara wanted to see more snowflakes falling down: one or more on the left half, as well as one or more on the right half.
+Looking at the snowflake fall down many times is nice. But, Clara
+wanted to see more snowflakes falling down: one or more on the left
+half, as well as one or more on the right half.
 
-Again, she needed to think in terms of programming. 
+Again, she needed to think in terms of programming.
 
-This would be "draw mutiple images with the different `x` parameters." The easiest way to do that is to copy-paste `(q/image @flake 400 state)` mutiple times with the different `x` parameters. For example,
+This would be "draw mutiple images with the different `x` parameters."
+The easiest way to do that is to copy-paste `(q/image @flake 400
+state)` mutiple times with the different `x` parameters. For example,
 
 ```clojure
 (q/image @flake 150 state)
@@ -323,9 +370,13 @@ This would be "draw mutiple images with the different `x` parameters." The easie
 (q/image @flake 650 state)
 ```
 
-But, for Clara, this did not look nice; she learned a lot about Clojure and wanted to use what she knew.
+But, for Clara, this did not look nice; she learned a lot about
+Clojure and wanted to use what she knew.
 
-First, she thought about how to keep multiple `x` parameters. She remembered there was a `vector` in the [Data Structures](https://github.com/ClojureBridge/curriculum/blob/master/outline/data_structures.md) section, which looked a good fit in this case.
+First, she thought about how to keep multiple `x` parameters. She
+remembered there was a `vector` in the
+[Data Structures](https://github.com/ClojureBridge/curriculum/blob/master/outline/data_structures.md)
+section, which looked a good fit in this case.
 
 Here's what she did to add more snowflakes:
 
@@ -378,20 +429,27 @@ At this point, `practice.clj` looks like this:
 Yeah! Clara saw three snowflakes that kept falling down.
 
 
-## Step 5. Make snowflakes keep falling down at different rates 
+## Step 5. Make snowflakes keep falling down at different rates
 
 So far, so good.
 
-But, Clara felt something was not quite right. All three snowflakes fell down simultaneously, which does not look very natural. So, she wanted to make them fall down at different rates.
+But, Clara felt something was not quite right. All three snowflakes
+fell down simultaneously, which does not look very natural. So, she
+wanted to make them fall down at different rates.
 
-Using programming terms, the problem here is that all three snowflakes share the same `y` parameter.
+Using programming terms, the problem here is that all three snowflakes
+share the same `y` parameter.
 
 Adding multiple `y` values would solve the problem--but how?
 
-As she used `vector` for the x parameters, the `vector` is a good data structure for `y` parameters as well. But, not just the height; Clara wanted to change the speed of each snowflake falling down.
+As she used `vector` for the x parameters, the `vector` is a good data
+structure for `y` parameters as well. But, not just the height; Clara
+wanted to change the speed of each snowflake falling down.
 
 So, she looked at the ClojureBridge curriculum page
-[More Data Structures](https://github.com/ClojureBridge/curriculum/blob/master/outline/data_structures2.md) and found the `Maps` section. Then, she changed the `state` from a single value to a vector of 3 maps.
+[More Data Structures](https://github.com/ClojureBridge/curriculum/blob/master/outline/data_structures2.md)
+and found the `Maps` section. Then, she changed the `state` from a
+single value to a vector of 3 maps.
 
 ```clojure
 [{:y 10 :speed 1} {:y 300 :speed 5} {:y 100 :speed 3}]
@@ -399,11 +457,19 @@ So, she looked at the ClojureBridge curriculum page
 
 It was a nice data structure.
 
-However, her `update` function was not very simple anymore. She needed to update all `y` values in the three maps.
+However, her `update` function was not very simple anymore. She needed
+to update all `y` values in the three maps.
 
-She had already learned how to get and update the values in the map. There was an `assoc` function, which would change the value in a map, that appeared in [More Functions](https://github.com/ClojureBridge/curriculum/blob/master/outline/functions2.md). (See [http://clojuredocs.org/clojure.core/assoc](http://clojuredocs.org/clojure.core/assoc) for more info)
+She had already learned how to get and update the values in the
+map. There was an `assoc` function, which would change the value in a
+map, that appeared in
+[More Functions](https://github.com/ClojureBridge/curriculum/blob/master/outline/functions2.md). (See
+[http://clojuredocs.org/clojure.core/assoc](http://clojuredocs.org/clojure.core/assoc)
+for more info)
 
-To iterate over all elements in a vector, Clojure has a few functions. But, be careful! The `update` function must return the updated state.
+To iterate over all elements in a vector, Clojure has a few
+functions. But, be careful! The `update` function must return the
+updated state.
 
 So, she used `for` to update the state like this:
 
@@ -415,11 +481,15 @@ So, she used `for` to update the state like this:
   )
 ```
 
-Another challenge was the `draw` function. 
+Another challenge was the `draw` function.
 
-Clara found a couple of ways to repeat something in Clojure. Among them, she chose `dotimes` and `nth` to repeatedly draw images; the `nth` function is the one in [More Functions](https://github.com/ClojureBridge/curriculum/blob/master/outline/functions2.md)
+Clara found a couple of ways to repeat something in Clojure. Among
+them, she chose `dotimes` and `nth` to repeatedly draw images; the
+`nth` function is the one in
+[More Functions](https://github.com/ClojureBridge/curriculum/blob/master/outline/functions2.md)
 
-In this case, she knew there were exactly 3 snowflakes, so she changed the code to draw 3 snowflakes as shown below:
+In this case, she knew there were exactly 3 snowflakes, so she changed
+the code to draw 3 snowflakes as shown below:
 
 ```clojure
 (dotimes [n 3]
@@ -468,14 +538,18 @@ At this point, her entire `practice.clj` looks like this:
   :middleware [m/fun-mode])
 ```
 
-When she ran the code above, three snowflakes kept falling down at different speeds. It looked more natural.
+When she ran the code above, three snowflakes kept falling down at
+different speeds. It looked more natural.
 
 
 ## Step 6. Do some "refactoring"
 
-Clara looked at her `practice.clj`, thinking her code got longer. 
+Clara looked at her `practice.clj`, thinking her code got longer.
 
-When she looked at her code from top to bottom again, she thought "`x-params` may be part of the state." So, she changed her `state` to have the x parameter also, like `[{:x 100 :y 10 :speed 1} {:x 400 :y 300 :speed 5} {:x 700 :y 100 :speed 3}]`.
+When she looked at her code from top to bottom again, she thought
+"`x-params` may be part of the state." So, she changed her `state` to
+have the x parameter also, like
+`[{:x 100 :y 10 :speed 1} {:x 400 :y 300 :speed 5} {:x 700 :y 100 :speed 3}]`.
 
 She found that this new format was easy to maintain the state of each snowflake.
 
@@ -490,11 +564,16 @@ At first, she wrote it like this:
 
 But, the exact the same thing, `(nth state n)`, appeared twice.
 
-"Is there anything to avoid repetition?" she thought. She went to [Clojure Cheat Sheet](http://clojure.org/cheatsheet) to figure out the `dotimes` syntax. Then, she clicked on `dotimes` in the "Macros, Loops" section and saw the syntax described in [dotimes](http://clojuredocs.org/clojure.core/dotimes).
+"Is there anything to avoid repetition?" she thought. She went to
+[Clojure Cheat Sheet](http://clojure.org/cheatsheet) to figure out the
+`dotimes` syntax. Then, she clicked on `dotimes` in the "Macros,
+Loops" section and saw the syntax described in
+[dotimes](http://clojuredocs.org/clojure.core/dotimes).
 
 It says `(dotimes bindings & body)`.
 
-Clara remembered that she learned `let` in [Flow Control](https://github.com/ClojureBridge/curriculum/blob/master/outline/flow_control.md),
+Clara remembered that she learned `let` in
+[Flow Control](https://github.com/ClojureBridge/curriculum/blob/master/outline/flow_control.md),
 which was "bindings". So, she rewrote it using `let` like this:
 
 ```clojure
@@ -547,16 +626,22 @@ At this moment, her entire `practice.clj` looks like this:
   :middleware [m/fun-mode])
 ```
 
-She saw the exact same result as the previous code, but her code looked nicer. This sort of work is often called "refactoring".
-
+She saw the exact same result as the previous code, but her code
+looked nicer. This sort of work is often called "refactoring".
 
 ## Step 7. Make snowflakes swing as they fall down
 
-Clara was getting familiar with Clojure coding. Her Quil app was getting much better, as well!
+Clara was getting familiar with Clojure coding. Her Quil app was
+getting much better, as well!
 
-However, looking at the snowflakes falling down, she thought she could swing them left and the right as they fall down. Right now, all of the snowflakes were falling straight down.
+However, looking at the snowflakes falling down, she thought she could
+swing them left and the right as they fall down. Right now, all of the
+snowflakes were falling straight down.
 
-In programming terms, the `x` parameter should both increase and decrease when the value is updated. This means that the `update` function should update the `x` parameters as well as the `y` parameters.
+In programming terms, the `x` parameter should both increase and
+decrease when the value is updated. This means that the `update`
+function should update the `x` parameters as well as the `y`
+parameters.
 
 To write this feature, she changed the initial state to this:
 
@@ -566,14 +651,23 @@ To write this feature, she changed the initial state to this:
  {:x 700 :swing 8 :y 100 :speed 9}]
 ```
 
-The map got a new `:swing` key, which holds a range of left and right from a current position.
+The map got a new `:swing` key, which holds a range of left and right
+from a current position.
 
-This means that the updated `x` parameter will have a value between the current `x` parameter + `swing` and the current `x` parameter - `swing`. For example, the first snowflake's next `x` parameter will be between `100 + 10` and `100 - 10`.
+This means that the updated `x` parameter will have a value between
+the current `x` parameter + `swing` and the current `x` parameter -
+`swing`. For example, the first snowflake's next `x` parameter will be
+between `100 + 10` and `100 - 10`.
 
-To update the `x` parameter by a random value between some range, she needed to do something not just using the existing clojure functions.
-She found [`rand-int`](http://clojuredocs.org/clojure.core/rand-int) from [Clojure Cheat Sheet](http://clojure.org/cheatsheet), but it only returned between `0` and a specified value. 
+To update the `x` parameter by a random value between some range, she
+needed to do something not just using the existing clojure functions.
+She found [`rand-int`](http://clojuredocs.org/clojure.core/rand-int)
+from [Clojure Cheat Sheet](http://clojure.org/cheatsheet), but it only
+returned between `0` and a specified value.
 
-Googling led her to this clojure code (from [https://github.com/sjl/roul/blob/master/src/roul/random.clj](https://github.com/sjl/roul/blob/master/src/roul/random.clj) ):
+Googling led her to this clojure code (from
+[https://github.com/sjl/roul/blob/master/src/roul/random.clj](https://github.com/sjl/roul/blob/master/src/roul/random.clj)
+):
 
 ```clojure
 (defn rand-int
@@ -584,11 +678,17 @@ Googling led her to this clojure code (from [https://github.com/sjl/roul/blob/ma
   ([start end] (+ start (clojure.core/rand-int (- end start)))))
 ```
 
-This was the random generation function that she wanted. But, she wanted a bit more.
+This was the random generation function that she wanted. But, she
+wanted a bit more.
 
-When the value goes to less than `0`, it should take the value of the image width, so that the snowflake will appear from the right. Likewise, when the value goes more than the image width, it should have value `0` so that the snowflake will appear from the left.
+When the value goes to less than `0`, it should take the value of the
+image width, so that the snowflake will appear from the
+right. Likewise, when the value goes more than the image width, it
+should have value `0` so that the snowflake will appear from the left.
 
-She couldn't use `if` anymore here, since `if` takes only one predicate (comparison). Instead of `if`, she used `cond` and wrote an `update-x` funcion.
+She couldn't use `if` anymore here, since `if` takes only one
+predicate (comparison). Instead of `if`, she used `cond` and wrote an
+`update-x` funcion.
 
 ```clojure
 (defn update-x
@@ -602,7 +702,9 @@ She couldn't use `if` anymore here, since `if` takes only one predicate (compari
      :else new-x )))
 ```
 
-This `update-x` function hinted to her that she could refactor the update function and write an `update-y` function. The below is the `update-y` function.
+This `update-x` function hinted to her that she could refactor the
+update function and write an `update-y` function. The below is the
+`update-y` function.
 
 ```clojure
 (defn update-y
@@ -620,7 +722,9 @@ She could still use `assoc`, but it would be like this:
 (assoc (assoc p :y (update-y (:y p) (:speed p))) :x (update-x (:x p) (:swing p)))
 ```
 
-She remembered that there was another function for maps. It was `merge`, which was appeared in [More Functions](https://github.com/ClojureBridge/curriculum/blob/master/outline/functions2.md).
+She remembered that there was another function for maps. It was
+`merge`, which was appeared in
+[More Functions](https://github.com/ClojureBridge/curriculum/blob/master/outline/functions2.md).
 
 Using `merge`, her `update` function turned into this:
 
@@ -689,9 +793,11 @@ At this point, her entire `practice.clj` looks like this:
 
 (frame-rate has been changed to 30)
 
-When Clara ran this code, she saw snowflakes were falling down, swinging left and right randomly.
+When Clara ran this code, she saw snowflakes were falling down,
+swinging left and right randomly.
 
-Even though there were a couple of problems as well as room for more refactoring, Clara was satified with her app. Moreover, she started thinking about her next, more advanced app in Clojure!
+Even though there were a couple of problems as well as room for more
+refactoring, Clara was satified with her app. Moreover, she started
+thinking about her next, more advanced app in Clojure!
 
-
-The end.
+The End.

--- a/curriculum/first-program.md
+++ b/curriculum/first-program.md
@@ -1,13 +1,21 @@
 Making Your First Program with Quil
 ===================================
 
-Now that you know a bit about how to write Clojure code, let's look at how to create a standalone application.
+Now that you know a bit about how to write Clojure code, let's look at
+how to create a standalone application.
 
-In order to do that, you'll first create a *project*. You'll learn how to organize your project with *namespaces*. You'll also learn how to specify your project's *dependencies*. Finally, you'll learn how to *build* your project to create the standalone application.
+In order to do that, you'll first create a *project*. You'll learn how
+to organize your project with *namespaces*. You'll also learn how to
+specify your project's *dependencies*. Finally, you'll learn how to
+*build* your project to create the standalone application.
 
 ## Create a Project
 
-Up until now you've been experimenting in a REPL. Unfortunately, all the work you do in a REPL is lost when you close the REPL. You can think of a project as a permanent home for your code. You'll be using a tool called "Leiningen" to help you create and manage your project. To create a new project, run this command:
+Up until now you've been experimenting in a REPL. Unfortunately, all
+the work you do in a REPL is lost when you close the REPL. You can
+think of a project as a permanent home for your code. You'll be using
+a tool called "Leiningen" to help you create and manage your
+project. To create a new project, run this command:
 
 ```clojure
 lein new quil drawing
@@ -20,11 +28,15 @@ This should create a directory structure that looks like this:
 | README.md
 | project.clj
 | src
-| | drawing 
+| | drawing
 | | | core.clj
 ```
 
-There's nothing inherently special or Clojure-y about this project skeleton. It's just a convention used by Leiningen. You'll be using Leiningen to build and run Clojure apps, and Leiningen expects your app to be laid out this way. Here's the function of each part of the skeleton:
+There's nothing inherently special or Clojure-y about this project
+skeleton. It's just a convention used by Leiningen. You'll be using
+Leiningen to build and run Clojure apps, and Leiningen expects your
+app to be laid out this way. Here's the function of each part of the
+skeleton:
 
 - `project.clj` is a configuration file for Leiningen. It helps
   Leiningen answer questions like, "What dependencies does this
@@ -32,45 +44,69 @@ There's nothing inherently special or Clojure-y about this project skeleton. It'
   should get executed first?"
 - `src/drawing/core.clj` is where the Clojure code goes
 
-This uses a Clojure library, Quil, that creates drawings called sketches.
+This uses a Clojure library, Quil, that creates drawings called
+sketches.
 
-Now let's go ahead and actually run the Quil sketch. Open up Light Table and do File - Open Folder - find the drawing folder and click Upload
+Now let's go ahead and actually run the Quil sketch. Open up Light
+Table and do File - Open Folder - find the drawing folder and click
+Upload
 
-Press `Ctrl + Shift + Enter` (or `Cmd + Shift + Enter`) to evaluate the file.
+Press `Ctrl + Shift + Enter` (or `Cmd + Shift + Enter`) to evaluate
+the file.
 
 ## Modify Project
 
-Let's create another Quil sketch. In Light Table, do File - New File. Do File - Save File As - Enter lines.clj as the name - and select the directory - drawing/src/drawing - then click Save. 
+Let's create another Quil sketch. In Light Table, do File - New
+File. Do File - Save File As - Enter lines.clj as the name - and
+select the directory - drawing/src/drawing - then click Save.
 
 ## Organization
 
-As your programs get more complex, you'll need to organize them. You organize your Clojure code by placing related functions and data in separate files. Clojure expects each file to correspond to a *namespace*, so you must *declare* a namespace at the top of each file.
+As your programs get more complex, you'll need to organize them. You
+organize your Clojure code by placing related functions and data in
+separate files. Clojure expects each file to correspond to a
+*namespace*, so you must *declare* a namespace at the top of each
+file.
 
-Until now, you haven't really had to care about namespaces. Namespaces allow you to define new functions and data structures without worrying about whether the name you'd like is already taken. For example, you could create a function named `println` within the custom namespace `my-special-namespace`, and it would not interfere with Clojure's built-in `println` function. You can use the *fully-qualified name* `my-special-namespace/println` to distinguish your function from the built-in `println`.
+Until now, you haven't really had to care about namespaces. Namespaces
+allow you to define new functions and data structures without worrying
+about whether the name you'd like is already taken. For example, you
+could create a function named `println` within the custom namespace
+`my-special-namespace`, and it would not interfere with Clojure's
+built-in `println` function. You can use the *fully-qualified name*
+`my-special-namespace/println` to distinguish your function from the
+built-in `println`.
 
-Create a namespace in the file `src/drawing/lines.clj`. Open it, and type the following:
+Create a namespace in the file `src/drawing/lines.clj`. Open it, and
+type the following:
 
 ```clojure
 (ns drawing.lines)
 ```
 
-This line establishes that everything you define in this file will be stored within the `drawing.lines` namespace.
-
+This line establishes that everything you define in this file will be
+stored within the `drawing.lines` namespace.
 
 ## Dependencies
 
-The final part of working with projects is managing their *dependencies*. Dependencies are just code libraries that others have written which you can incorporate in your own project.
+The final part of working with projects is managing their
+*dependencies*. Dependencies are just code libraries that others have
+written which you can incorporate in your own project.
 
-To add a dependency, open `project.clj`. You should see a section which reads
+To add a dependency, open `project.clj`. You should see a section
+which reads
 
 ```clj
 :dependencies [[org.clojure/clojure "1.6.0"]
                [quil "2.2.2"]])
 ```
 
-This is where our dependencies are listed. All the dependencies we need for this project are already included.
+This is where our dependencies are listed. All the dependencies we
+need for this project are already included.
 
-In order to use these libraries, we have to _require_ them in our own project. In `src/drawing/lines.clj`, edit the ns statement you typed before:
+In order to use these libraries, we have to _require_ them in our own
+project. In `src/drawing/lines.clj`, edit the ns statement you typed
+before:
 
 ```clojure
 (ns drawing.lines
@@ -79,13 +115,19 @@ In order to use these libraries, we have to _require_ them in our own project. I
 
 This gives us access to the library we will need to make our project.
 
-There are a couple of things going on here. First, the `:require` in `ns` tells Clojure to load other namespaces. The `:as` part of `:require` creates an *alias* for a namespace, letting you refer to its definitions without having to type out the entire namespace. For example, you can use `q/fill` instead of `quil.core/fill`.
+There are a couple of things going on here. First, the `:require` in
+`ns` tells Clojure to load other namespaces. The `:as` part of
+`:require` creates an *alias* for a namespace, letting you refer to
+its definitions without having to type out the entire namespace. For
+example, you can use `q/fill` instead of `quil.core/fill`.
 
 ## Your first real program
 
 ### Drawing with Quil
 
-Quil is a Clojure library that provides the powers of Processing, a tool that allows you to create drawings and animations. We will use the functions of Quil to create some of our own drawings. 
+Quil is a Clojure library that provides the powers of Processing, a
+tool that allows you to create drawings and animations. We will use
+the functions of Quil to create some of our own drawings.
 
 We will define our own functions, like so...
 
@@ -110,27 +152,42 @@ Put it together:
    )
 ```
 
-In order to create a drawing (or sketch in Quil lingo) with Quil, you have to define the `setup`, `draw`, and `sketch` functions. `setup` is where you set the stage for your drawing. `draw` happens repeatedly, so that is where the action of your drawing happens. `sketch` is the stage itself. Let's define these functions together, and you will see what they do.
+In order to create a drawing (or sketch in Quil lingo) with Quil, you
+have to define the `setup`, `draw`, and `sketch` functions. `setup` is
+where you set the stage for your drawing. `draw` happens repeatedly,
+so that is where the action of your drawing happens. `sketch` is the
+stage itself. Let's define these functions together, and you will see
+what they do.
 
-In Light Table, in the lines.clj file, add the following after the closing parenthesis of the ns statement from before.
+In Light Table, in the lines.clj file, add the following after the
+closing parenthesis of the ns statement from before.
 
 ```clojure
 (defn setup []
 
-  (q/frame-rate 30) 
+  (q/frame-rate 30)
 
   (q/color-mode :rgb)
 
-  (q/stroke 255 0 0)) 
+  (q/stroke 255 0 0))
 ```
 
-This is the `setup` function that sets the stage for the drawing. First, we call quil's `frame-rate` function to say that the drawing should be redrawn 30 times per second. We put `q/` in front to say that this is `frame-rate` from quil. Look up at the ns statement. Since it says `:as q`, we can use q as a short hand for quil, and `library-name/function-name` is the way you call a function from a library.
+This is the `setup` function that sets the stage for the
+drawing. First, we call quil's `frame-rate` function to say that the
+drawing should be redrawn 30 times per second. We put `q/` in front to
+say that this is `frame-rate` from quil. Look up at the ns
+statement. Since it says `:as q`, we can use q as a short hand for
+quil, and `library-name/function-name` is the way you call a function
+from a library.
 
 Second, we set the color mode to RGB.
 
-Third, we set the color of the lines we will draw with `stroke`. The code 255 0 0 represents red. You can look up RGB codes for other colors if you would like to try something else.
+Third, we set the color of the lines we will draw with `stroke`. The
+code 255 0 0 represents red. You can look up RGB codes for other
+colors if you would like to try something else.
 
-In Light Table, in the lines.clj file, add the following after the closing parenthesis of the setup function.
+In Light Table, in the lines.clj file, add the following after the
+closing parenthesis of the setup function.
 
 ```clojure
 (defn draw []
@@ -144,7 +201,15 @@ In Light Table, in the lines.clj file, add the following after the closing paren
   (q/line 200 200 (q/mouse-x) (q/mouse-y)))
 ```
 
-Here we call the quil `line` function four times. We also call two functions repeatedly as the arguments to the `line` function: `mouse-x` and `mouse-y`. These get the current position (x and y coordinates on a 2d plane) of the mouse. The `line` function takes four arguments - two sets of x, y coordinates. The first x and y are the starting position of the line. The second x and y are the ending position of the line. So we start each of these lines at a fixed position, then end them wherever the mouse is when the sketch is drawn.
+Here we call the quil `line` function four times. We also call two
+functions repeatedly as the arguments to the `line` function:
+`mouse-x` and `mouse-y`. These get the current position (x and y
+coordinates on a 2d plane) of the mouse. The `line` function takes
+four arguments - two sets of x, y coordinates. The first x and y are
+the starting position of the line. The second x and y are the ending
+position of the line. So we start each of these lines at a fixed
+position, then end them wherever the mouse is when the sketch is
+drawn.
 
 ```clojure
 (q/defsketch hello-lines
@@ -158,11 +223,15 @@ Here we call the quil `line` function four times. We also call two functions rep
   :draw draw )
 ```
 
-This is our sketch. You can set attributes of the sketch such as the title and size. You also tell it what are the names of the setup and draw functions. These have to match exactly the function names we used above.
+This is our sketch. You can set attributes of the sketch such as the
+title and size. You also tell it what are the names of the setup and
+draw functions. These have to match exactly the function names we used
+above.
 
-Now press `Ctrl + Shift + Enter` (or `Cmd + Shift + Enter`) to evaluate the file. Your drawing should appear.
+Now press `Ctrl + Shift + Enter` (or `Cmd + Shift + Enter`) to
+evaluate the file. Your drawing should appear.
 
-### Exercise: Rainbow lines 
+### Exercise: Rainbow lines
 Update your drawing so that:
 * the lines are a different color
 * the title is different

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,11 @@
 (defproject drawing "0.1.0-SNAPSHOT"
+
   :description "ClojureBridge capstone app that uses Quil for drawing"
+
   :url "http://clojurebridge.org"
+
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [quil "2.2.1"]])


### PR DESCRIPTION
Some of the curriculum text is difficult to edit, as is, so I've added line wrapping in the curricular documents, changed some capitalization, and inserted white space into the `project.clj`.