### PR TITLE
Keep sketches on top of other windows, for easier instant feedback.

### DIFF
--- a/src/drawing/core.clj
+++ b/src/drawing/core.clj
@@ -41,6 +41,7 @@
   ; It updates sketch state.
   :update update
   :draw draw
+  :features [:keep-on-top]
   ; This sketch uses functional-mode middleware.
   ; Check quil wiki for more info about middlewares and particularly
   ; fun-mode.

--- a/src/drawing/lines.clj
+++ b/src/drawing/lines.clj
@@ -43,4 +43,5 @@
   ; setup function is called setup
   :setup setup
   ; draw function is called draw
-  :draw draw )
+  :draw draw
+  :features [:keep-on-top])

--- a/src/drawing/practice.clj
+++ b/src/drawing/practice.clj
@@ -50,4 +50,5 @@
   :setup setup
   :update update
   :draw draw
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/src/drawing/step1.clj
+++ b/src/drawing/step1.clj
@@ -21,4 +21,4 @@
   :size [1000 1000]
   :setup setup
   :draw draw
-  )
+  :features [:keep-on-top])

--- a/src/drawing/step2.clj
+++ b/src/drawing/step2.clj
@@ -29,4 +29,5 @@
   :setup setup
   :update update
   :draw draw
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/src/drawing/step3.clj
+++ b/src/drawing/step3.clj
@@ -32,4 +32,5 @@
   :setup setup
   :update update
   :draw draw
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/src/drawing/step4.clj
+++ b/src/drawing/step4.clj
@@ -33,4 +33,5 @@
   :setup setup
   :update update
   :draw draw
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/src/drawing/step5.clj
+++ b/src/drawing/step5.clj
@@ -34,4 +34,5 @@
   :setup setup
   :update update
   :draw draw
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/src/drawing/step6.clj
+++ b/src/drawing/step6.clj
@@ -34,4 +34,5 @@
   :setup setup
   :update update
   :draw draw
+  :features [:keep-on-top]
   :middleware [m/fun-mode])


### PR DESCRIPTION
I believe learners would have a much easier time if sketches were kept on top of other windows.

**Positives:**
- Doesn't require moving windows around to accomodate sketch, for instant feedback.
- Mac users don't panic wondering why Quil doesn't work. (When the sketch is just [hiding under other windows](https://github.com/quil/quil/wiki/FAQ#i-cannot-see-sketch-on-os-x).)

**Negatives:**
- Code becomes 1 line more complex.
- Big sketches hide the text editor, so you'll often move the sketch to the side or another screen.

**Tested** on MacOS X.

(`lein new quil <my-project>` now does this by default: https://github.com/quil/quil-templates/pull/5)
